### PR TITLE
Fix missing controllerModel reference

### DIFF
--- a/examples/jsm/webxr/XRControllerModelFactory.js
+++ b/examples/jsm/webxr/XRControllerModelFactory.js
@@ -281,7 +281,7 @@ var XRControllerModelFactory = ( function () {
 						null,
 						() => {
 
-							throw new Error( `Asset ${motionController.assetUrl} missing or malformed.` );
+							throw new Error( `Asset ${controllerModel.motionController.assetUrl} missing or malformed.` );
 
 						} );
 


### PR DESCRIPTION
The controllerModel was missing in error. So calling motionController.assertUrl will be undefined.